### PR TITLE
Adds a date field to the main home page that works

### DIFF
--- a/src/main/java/org/launchcode/VennTime/models/AvailabilityRange.java
+++ b/src/main/java/org/launchcode/VennTime/models/AvailabilityRange.java
@@ -6,6 +6,14 @@ import java.sql.Timestamp;
 @Embeddable
 public class AvailabilityRange {
 
+    public AvailabilityRange() {
+    }
+
+    public AvailabilityRange(Timestamp startTime, Timestamp endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
     private Timestamp startTime;
 
     private Timestamp endTime;

--- a/src/main/java/org/launchcode/VennTime/models/Event.java
+++ b/src/main/java/org/launchcode/VennTime/models/Event.java
@@ -1,6 +1,7 @@
 package org.launchcode.VennTime.models;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -16,7 +17,10 @@ public class Event extends AbstractEntity{
     @OneToMany
     private List<Attendee> attendees;
 
-    public Event() {}
+    public Event() {
+        this.availabilityRanges = new ArrayList<AvailabilityRange>();
+        this.attendees = new ArrayList<Attendee>();
+    }
 
     public Event(String name, String description, List<AvailabilityRange> availabilityRanges, List<Attendee> attendees) {
         this.name = name;

--- a/src/main/java/org/launchcode/VennTime/models/dto/CreateEventDTO.java
+++ b/src/main/java/org/launchcode/VennTime/models/dto/CreateEventDTO.java
@@ -1,10 +1,17 @@
 package org.launchcode.VennTime.models.dto;
 
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
 public class CreateEventDTO {
 
     private String name;
 
     private String description;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
 
     public CreateEventDTO() {
     }
@@ -23,5 +30,13 @@ public class CreateEventDTO {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
     }
 }

--- a/src/main/java/org/launchcode/VennTime/models/mapper/DTOMapper.java
+++ b/src/main/java/org/launchcode/VennTime/models/mapper/DTOMapper.java
@@ -1,8 +1,14 @@
 package org.launchcode.VennTime.models.mapper;
 
+import org.launchcode.VennTime.models.AvailabilityRange;
 import org.launchcode.VennTime.models.Event;
 import org.launchcode.VennTime.models.dto.CreateEventDTO;
 import org.springframework.stereotype.Component;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 
 @Component
 public class DTOMapper {
@@ -11,6 +17,12 @@ public class DTOMapper {
         Event newEvent = new Event();
         newEvent.setName(createEventDTO.getName());
         newEvent.setDescription(createEventDTO.getDescription());
+        Instant startInstant = createEventDTO.getDate().atTime(12, 30).atZone(ZoneId.of("America/New_York")).toInstant();
+        Instant endInstant = startInstant.plusSeconds(3600);
+        Timestamp startTime = new Timestamp(startInstant.toEpochMilli());
+        Timestamp endTime = new Timestamp(endInstant.toEpochMilli());
+        AvailabilityRange availabilityRange = new AvailabilityRange(startTime, endTime);
+        newEvent.getAvailabilityRanges().add(availabilityRange);
         return newEvent;
     }
 }

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -13,7 +13,7 @@
     <textarea th:field="${createEventDTO.description}">
         Event Description
     </textarea>
-    <input type="time" name="timestamp">
+    <input type="date" th:field="${createEventDTO.date}">
     <input type="submit"/>
 
 </form>


### PR DESCRIPTION
Adds a date input to the main page that works to add a single availability range to the date. 

I set the time to 1230 in the dto mapper to mock the functionality until we implement a way to set the start and end times.