### PR TITLE
Add start, end and timezone to form, dto and mapper

### DIFF
--- a/src/main/java/org/launchcode/VennTime/models/dto/CreateEventDTO.java
+++ b/src/main/java/org/launchcode/VennTime/models/dto/CreateEventDTO.java
@@ -3,6 +3,9 @@ package org.launchcode.VennTime.models.dto;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.*;
 
 public class CreateEventDTO {
 
@@ -13,7 +16,18 @@ public class CreateEventDTO {
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
+    @DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
+    private LocalTime startTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
+    private LocalTime endTime;
+
+    private String timezone;
+
+    private static final List<String> possibleTimezones = new ArrayList<>(ZoneId.getAvailableZoneIds());
+
     public CreateEventDTO() {
+        Collections.sort(possibleTimezones);
     }
 
     public String getName() {
@@ -38,5 +52,33 @@ public class CreateEventDTO {
 
     public void setDate(LocalDate date) {
         this.date = date;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public List<String> getPossibleTimezones() {
+        return possibleTimezones;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
     }
 }

--- a/src/main/java/org/launchcode/VennTime/models/mapper/DTOMapper.java
+++ b/src/main/java/org/launchcode/VennTime/models/mapper/DTOMapper.java
@@ -17,8 +17,8 @@ public class DTOMapper {
         Event newEvent = new Event();
         newEvent.setName(createEventDTO.getName());
         newEvent.setDescription(createEventDTO.getDescription());
-        Instant startInstant = createEventDTO.getDate().atTime(12, 30).atZone(ZoneId.of("America/New_York")).toInstant();
-        Instant endInstant = startInstant.plusSeconds(3600);
+        Instant startInstant = createEventDTO.getDate().atTime(createEventDTO.getStartTime()).atZone(ZoneId.of(createEventDTO.getTimezone())).toInstant();
+        Instant endInstant = createEventDTO.getDate().atTime(createEventDTO.getEndTime()).atZone(ZoneId.of(createEventDTO.getTimezone())).toInstant();
         Timestamp startTime = new Timestamp(startInstant.toEpochMilli());
         Timestamp endTime = new Timestamp(endInstant.toEpochMilli());
         AvailabilityRange availabilityRange = new AvailabilityRange(startTime, endTime);

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -13,6 +13,13 @@
         Event Description
     </textarea>
     <input type="date" th:field="${createEventDTO.date}">
+    <input type="time" name="startTime"/>
+    <input type="time" name="endTime"/>
+    <select th:field="${createEventDTO.timezone}">
+        <th:block th:each="possibleTimezone : ${createEventDTO.getPossibleTimezones}">
+            <option th:value="${possibleTimezone}" th:text="${possibleTimezone}"></option>
+        </th:block>
+    </select>
     <input type="submit"/>
 
 </form>


### PR DESCRIPTION
Adds a start time, end time and timezone to the landing page form. Also adds appropriate field to DTO and updates mapper to correctly generate availability ranges from form input