### PR TITLE
Maxray/start and end time initialize on home page

### DIFF
--- a/src/main/java/org/launchcode/VennTime/models/dto/CreateEventDTO.java
+++ b/src/main/java/org/launchcode/VennTime/models/dto/CreateEventDTO.java
@@ -34,6 +34,8 @@ public class CreateEventDTO {
     private static final List<String> possibleTimezones = new ArrayList<>(ZoneId.getAvailableZoneIds());
 
     public CreateEventDTO() {
+        this.startTime = LocalTime.of(9,0);
+        this.endTime = LocalTime.of(17,0);
         Collections.sort(possibleTimezones);
     }
 

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -115,23 +115,6 @@ border-width: 0px 0px 0px 5px;
      cursor: pointer;
 }
 
- input[type="time"] {
-    background: #fff;
-    height:30px;
-    min-width: 150px;
-}
-
- input[type="time"]:before {
-    content: '9:00 AM';
-    color: #9d9d9d;
-    position: absolute;
-    background: #fff;
-    height: 18px;
-}
-
-input[type="time"]:hover:before {
-    content: '9:00 AM';
-}
 
 .progress-bar {
 background-color: #95D24F


### PR DESCRIPTION
fixes start and end time on the create event page to be initialized at 9 and 5, removes old css that did something similar